### PR TITLE
Fix building without the "parallel" feature

### DIFF
--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -4,12 +4,14 @@ use hashbrown::HashMap;
 
 use crate::{
     dispatch::{
-        dispatcher::{SystemId, ThreadLocal, ThreadPoolWrapper},
+        dispatcher::{SystemId, ThreadLocal},
         stage::StagesBuilder,
         BatchAccessor, BatchController, Dispatcher,
     },
     system::{RunNow, System, SystemData},
 };
+#[cfg(feature = "parallel")]
+use crate::dispatch::dispatcher::ThreadPoolWrapper;
 
 /// Builder for the [`Dispatcher`].
 ///
@@ -235,7 +237,10 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     ) where
         T: for<'c> System<'c> + BatchController<'a, 'b> + Send + 'a,
     {
-        dispatcher_builder.thread_pool = self.thread_pool.clone();
+        #[cfg(feature = "parallel")]
+        {
+            dispatcher_builder.thread_pool = self.thread_pool.clone();
+        }
 
         let mut reads = dispatcher_builder.stages_builder.fetch_all_reads();
         reads.extend(<T::BatchSystemData as SystemData>::reads());

--- a/src/dispatch/dispatcher.rs
+++ b/src/dispatch/dispatcher.rs
@@ -4,6 +4,7 @@ use crate::{dispatch::stage::Stage, system::RunNow, world::World};
 
 /// This wrapper is used to share a replaceable ThreadPool with other
 /// dispatchers. Useful with batch dispatchers.
+#[cfg(feature = "parallel")]
 pub type ThreadPoolWrapper = Option<::std::sync::Arc<::rayon::ThreadPool>>;
 
 /// The dispatcher struct, allowing


### PR DESCRIPTION
Seems like this was broken between `0.9.2` and `0.9.3`.

I'm not at all familiar with this code base, so please let me know if there is a better way to do this. That said, this compiles and unblocks my project locally.