### PR TITLE
Bump `tynm` to `0.1.3` to be compatible with Rust 1.38.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+* Bump `tynm` to `0.1.3`. ([#187])
+
+[#187]: https://github.com/amethyst/shred/pulls/187
+
 ## 0.10.0 (2019-12-31)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ mopa = "0.2.2"
 rayon = { version = "1.3.0", optional = true }
 shred-derive = { path = "shred-derive", version = "0.6.0", optional = true }
 smallvec = "1.1.0"
-tynm = "0.1.0"
+tynm = "0.1.3"
 
 [workspace]
 members = ["shred-derive"]


### PR DESCRIPTION
`tynm 0.1.2` used the `todo!()` macro which is only stable in Rust 1.40. `tynm 0.1.3` switches that to `unimplemented!()` to be compatible with Rust 1.38.

This change ensures the fix is used (though consumers may already receive it simply with `cargo update`).