### PR TITLE
Bumped `shred-derive` version to `0.6.2`.

### DIFF
--- a/shred-derive/Cargo.toml
+++ b/shred-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred-derive"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["torkleyy"]
 description = "Custom derive for shred"
 documentation = "https://docs.rs/shred_derive"


### PR DESCRIPTION
Needed for #188.