### PR TITLE
WIP/PoC: Batch api ergonomics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+* Batch dispatching ergonomics (getting rid of unsafe on the user side)
+  ([#197]).
+
 ## 0.10.2 (2020-02-13)
 
 ### Changed

--- a/src/dispatch/mod.rs
+++ b/src/dispatch/mod.rs
@@ -3,7 +3,10 @@ pub use self::async_dispatcher::AsyncDispatcher;
 #[cfg(feature = "parallel")]
 pub use self::par_seq::{Par, ParSeq, RunWithPool, Seq};
 pub use self::{
-    batch::{BatchAccessor, BatchController, BatchUncheckedWorld, DefaultBatchControllerSystem},
+    batch::{
+        BatchAccessor, BatchController, BatchUncheckedWorld, MultiDispatchController,
+        MultiDispatcher,
+    },
     builder::DispatcherBuilder,
     dispatcher::Dispatcher,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,8 +102,8 @@ pub use crate::dispatch::AsyncDispatcher;
 pub use crate::dispatch::{Par, ParSeq, RunWithPool, Seq};
 pub use crate::{
     dispatch::{
-        BatchAccessor, BatchController, BatchUncheckedWorld, DefaultBatchControllerSystem,
-        Dispatcher, DispatcherBuilder,
+        BatchAccessor, BatchController, BatchUncheckedWorld, Dispatcher, DispatcherBuilder,
+        MultiDispatchController, MultiDispatcher,
     },
     meta::{CastFrom, MetaIter, MetaIterMut, MetaTable},
     system::{

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -353,7 +353,6 @@ fn assert_unsized<T: ?Sized>() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use World;
 
     trait Object {
         fn method1(&self) -> i32;


### PR DESCRIPTION
Hello

As mentioned in #197, I've sketched some API how the batch dispatching could be improved so it's less awkward and doesn't require unsafe.

This is very much a PoC/WiP, I don't want to merge it as it is. I know there are missing docs, copy-pasted comments that are out of context, extra includes that are no longer needed, some things are public when in fact shouldn't be and in general a lot of garbage. I plan to clean it up before asking for it to get merged.

What I would like now is to have some feedback on the API. I have some specific questions, but any other suggestions are fine too:

* Naming. In particular, the simpler case where it is decided up-front how many times the sub-dispatcher should run is currently called multi-batch. I think this is a bad name, because it suggests it's somehow „more“ than the usual but more complex case.
* The multi-batch is a separate method of the builder. Alternatively, it could be exposed as the wrapper type and one could create it directly. I'm not sure on what's better.

In general, however, I feel like this makes the API more approachable (obviously, after it gets some docs and examples).

@azriel91 Do you think I should continue in this? (and, btw, there's a tiny doc update PR from me sitting there for some time as well).