### PR TITLE
Update hashbrown dependency v0.7.0 -> v0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "amethyst/shred" }
 
 [dependencies]
 arrayvec = "0.5.1"
-hashbrown = "0.7.0"
+hashbrown = "0.8.2"
 mopa = "0.2.2"
 rayon = { version = "1.3.0", optional = true }
 shred-derive = { path = "shred-derive", version = "0.6.0", optional = true }


### PR DESCRIPTION
[Changelog](https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md#v080---2020-06-18)