### PR TITLE
Update crate versions to `0.11.0` and `0.6.3`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Changelog
 
-* Batch dispatching ergonomics (getting rid of unsafe on the user side)
-  ([#197]).
+## 0.11.0 (2020-12-21)
+
+* Batch dispatching ergonomics -- remove `unsafe` on the user side. ([#197], [#198]).
+* Bumped dependency versions. ([#203], [#204])
+
+[#197]: https://github.com/amethyst/shred/issues/197
+[#198]: https://github.com/amethyst/shred/pull/198
+[#203]: https://github.com/amethyst/shred/issues/203
+[#204]: https://github.com/amethyst/shred/pull/204
 
 ## 0.10.2 (2020-02-13)
 
@@ -19,7 +26,7 @@
 * Implement `Resource` for `!Send + !Sync` types when `"parallel"` feature is disabled. ([#186])
 
 [#186]: https://github.com/amethyst/shred/pull/186
-[#187]: https://github.com/amethyst/shred/pulls/187
+[#187]: https://github.com/amethyst/shred/pull/187
 
 ## 0.10.0 (2019-12-31)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["torkleyy <torkleyy@gmail.com>"]
 description = """
 Dispatches systems in parallel which need read access to some resources,
@@ -23,7 +23,7 @@ arrayvec = "0.5.2"
 hashbrown = "0.9.1"
 mopa = "0.2.2"
 rayon = { version = "1.5.0", optional = true }
-shred-derive = { path = "shred-derive", version = "0.6.0", optional = true }
+shred-derive = { path = "shred-derive", version = "0.6.3", optional = true }
 smallvec = "1.5.1"
 tynm = "0.1.6"
 
@@ -32,7 +32,7 @@ members = ["shred-derive"]
 
 [dev-dependencies]
 cgmath = "0.17.0"
-shred-derive = { path = "shred-derive", version = "0.6.0" }
+shred-derive = { path = "shred-derive", version = "0.6.3" }
 
 [features]
 default = ["parallel", "shred-derive"]

--- a/shred-derive/Cargo.toml
+++ b/shred-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred-derive"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["torkleyy"]
 description = "Custom derive for shred"
 documentation = "https://docs.rs/shred_derive"


### PR DESCRIPTION
Release changes for `0.11.0`.