### PR TITLE
Added DispatcherBuilder::contains

### DIFF
--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -180,6 +180,12 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
         self.stages_builder.insert(dependencies, id, system);
     }
 
+    /// Returns `true` if a system with the given name has been added to the `BispatcherBuilder`,
+    /// otherwise, returns false.
+    pub fn contains(&self, name: &str) -> bool {
+        self.map.contains_key(name)
+    }
+
     /// The `Batch` is a `System` which contains a `Dispatcher`.
     /// By wrapping a `Dispatcher` inside a system, we can control the execution
     /// of a whole group of system, without sacrificing parallelism or


### PR DESCRIPTION
Adds a `contains` method to `DispatcherBuilder` that allows the caller to determine if a system with the given name has already been added.

This supports https://github.com/amethyst/specs/issues/736. 