### PR TITLE
Add getters to DispatcherBuilder

### DIFF
--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -112,6 +112,23 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
         Default::default()
     }
 
+    /// Returns whether or not any system has been added to the builder
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Returns the number of systems added to the builder
+    pub fn num_systems(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Returns whether or not a specific system has been added to the builder
+    /// This is useful as [`add()`](struct.DispatcherBuilder.html#method.add) will throw if a dependency does not exist
+    /// So you can use this function to check if dependencies are satisfied
+    pub fn has_system(&self, system: &str) -> bool {
+        self.map.contains_key(system)
+    }
+
     /// Adds a new system with a given name and a list of dependencies.
     /// Please note that the dependency should be added before
     /// you add the depending system.


### PR DESCRIPTION
For our system graph, it's possible that in the end no system actually needs to be executed at the  given moment. To avoid the overhead of calling ` dispatcher.dispatch(&world)` on an empty graph, I wanted to add an `is_empty` function that I can call before executing.

Similar, some systems may not need to run at some given time.  There are times in my code where a child task needs to run even if its dependency did not need to execute, and there are times where it doesn't need to run. In order to implement this logic, I added a `has_system` function so that I can check whether or not a dependency was skipped