### PR TITLE
update dependencies and switch to compare_exchange as its deprecated …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.40.0  # MSRV
+          - 1.56.1  # MSRV
 
     timeout-minutes: 10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Bumped dependency of `hashbrown` to `0.12`
 * Bumped dependency of `arrayvec` to `0.7.2`.
 * Add getters to DispatcherBuilder
-* increase minimal rust version to `1.40`
+* increase minimal rust version to `1.56.1`
 * improve performance by switching to `compare_exchange_weak`
 
 ## 0.12.0 (2021-03-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
+## 0.13.0 (2022-06-22)
+
+* Bumped dependency of `hashbrown` to `0.12`
+* Bumped dependency of `arrayvec` to `0.7.2`.
+* Add getters to DispatcherBuilder
+* increase minimal rust version to `1.40`
+* improve performance by switching to `compare_exchange_weak`
+
 ## 0.12.0 (2021-03-21)
 
-* Bumped depenceny of hashbrown to 0.11
+* Bumped dependency of `hashbrown` to `0.11`
 
 ## 0.11.1 (2021-03-10)
 
-* Bumped depenceny of smallvec as there was an open RUSTSEC issue 
+* Bumped dependency of smallvec as there was an open RUSTSEC issue
 
 ## 0.11.0 (2020-12-21)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ keywords = ["parallel", "systems", "resources", "ecs"]
 categories = ["concurrency"]
 license = "MIT OR Apache-2.0"
 exclude = ["bors.toml", ".travis.yml"]
-edition = "2018"
+edition = "2021"
+rust-version = "1.56.1"
 
 [badges]
 travis-ci = { repository = "amethyst/shred" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["torkleyy <torkleyy@gmail.com>"]
 description = """
 Dispatches systems in parallel which need read access to some resources,
@@ -19,8 +19,8 @@ edition = "2018"
 travis-ci = { repository = "amethyst/shred" }
 
 [dependencies]
-arrayvec = "0.5.2"
-hashbrown = "0.11"
+arrayvec = "0.7.2"
+hashbrown = "0.12"
 mopa = "0.2.2"
 rayon = { version = "1.5.0", optional = true }
 shred-derive = { path = "shred-derive", version = "0.6.3", optional = true }
@@ -31,7 +31,7 @@ tynm = "0.1.6"
 members = ["shred-derive"]
 
 [dev-dependencies]
-cgmath = "0.17.0"
+cgmath = "0.18.0"
 shred-derive = { path = "shred-derive", version = "0.6.3" }
 
 [features]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Please see [the benchmark](benches/bench.rs) for a bigger (and useful) example.
 
 ### Required Rust version
 
-`1.40 stable`
+`1.56.1 stable`
 
 ## Features
 

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -123,8 +123,9 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     }
 
     /// Returns whether or not a specific system has been added to the builder
-    /// This is useful as [`add()`](struct.DispatcherBuilder.html#method.add) will throw if a dependency does not exist
-    /// So you can use this function to check if dependencies are satisfied
+    /// This is useful as [`add()`](struct.DispatcherBuilder.html#method.add)
+    /// will throw if a dependency does not exist So you can use this
+    /// function to check if dependencies are satisfied
     pub fn has_system(&self, system: &str) -> bool {
         self.map.contains_key(system)
     }

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -78,7 +78,7 @@ enum InsertionTarget {
 
 #[derive(Default)]
 pub struct Stage<'a> {
-    groups: GroupVec<ArrayVec<[SystemExecSend<'a>; MAX_SYSTEMS_PER_GROUP]>>,
+    groups: GroupVec<ArrayVec<SystemExecSend<'a>, MAX_SYSTEMS_PER_GROUP>>,
 }
 
 impl<'a> Stage<'a> {
@@ -132,7 +132,7 @@ impl<'a> Stage<'a> {
 #[derive(Default)]
 pub struct StagesBuilder<'a> {
     barrier: usize,
-    ids: Vec<GroupVec<ArrayVec<[SystemId; MAX_SYSTEMS_PER_GROUP]>>>,
+    ids: Vec<GroupVec<ArrayVec<SystemId, MAX_SYSTEMS_PER_GROUP>>>,
     reads: Vec<GroupVec<SmallVec<[ResourceId; 12]>>>,
     running_time: Vec<GroupVec<u8>>,
     stages: Vec<Stage<'a>>,
@@ -323,7 +323,7 @@ impl<'a> StagesBuilder<'a> {
     /// Returns an enum indicating which kind of conflict a system has
     /// with a stage.
     fn find_conflict<'rw, R, W>(
-        ids: &[GroupVec<ArrayVec<[SystemId; MAX_SYSTEMS_PER_GROUP]>>],
+        ids: &[GroupVec<ArrayVec<SystemId, MAX_SYSTEMS_PER_GROUP>>],
         reads: &[GroupVec<SmallVec<[ResourceId; 12]>>],
         writes: &[GroupVec<SmallVec<[ResourceId; 10]>>],
         stage: usize,
@@ -391,9 +391,7 @@ impl<'a> StagesBuilder<'a> {
 mod tests {
     use super::*;
 
-    fn create_ids(
-        ids: &[&[&[usize]]],
-    ) -> Vec<GroupVec<ArrayVec<[SystemId; MAX_SYSTEMS_PER_GROUP]>>> {
+    fn create_ids(ids: &[&[&[usize]]]) -> Vec<GroupVec<ArrayVec<SystemId, MAX_SYSTEMS_PER_GROUP>>> {
         ids.iter()
             .map(|groups| {
                 groups


### PR DESCRIPTION
…since 1.50 (and still exists in 1.40)