### PR TITLE
Eliminate safety issue in Resource::downcast*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ travis-ci = { repository = "amethyst/shred" }
 [dependencies]
 arrayvec = "0.7.2"
 hashbrown = "0.12"
-mopa = "0.2.2"
 rayon = { version = "1.5.0", optional = true }
 shred-derive = { path = "shred-derive", version = "0.6.3", optional = true }
 smallvec = "1.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shred"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["torkleyy <torkleyy@gmail.com>"]
 description = """
 Dispatches systems in parallel which need read access to some resources,
@@ -17,7 +17,6 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [badges]
-travis-ci = { repository = "amethyst/shred" }
 
 [dependencies]
 arrayvec = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,8 @@ exclude = ["bors.toml", ".travis.yml"]
 edition = "2021"
 rust-version = "1.56.1"
 
-[badges]
-
 [dependencies]
 arrayvec = "0.7.2"
-hashbrown = "0.12"
 rayon = { version = "1.5.0", optional = true }
 shred-derive = { path = "shred-derive", version = "0.6.3", optional = true }
 smallvec = "1.6.1"

--- a/examples/dynamic_resource_id.rs
+++ b/examples/dynamic_resource_id.rs
@@ -13,7 +13,8 @@
 //! make it easier to understand. Make sure you understood a step before you go
 //! to the next.
 
-use hashbrown::HashMap;
+use std::collections::HashMap;
+
 use shred::{Accessor, AccessorCow, DynamicSystemData, Fetch, ResourceId, RunNow, System, World};
 
 // -- Step 1 - Define your resource type and an interface for registering it --

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -1,6 +1,7 @@
-use std::fmt;
-
-use hashbrown::HashMap;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    fmt,
+};
 
 #[cfg(feature = "parallel")]
 use crate::dispatch::dispatcher::ThreadPoolWrapper;
@@ -170,8 +171,6 @@ impl<'a, 'b> DispatcherBuilder<'a, 'b> {
     where
         T: for<'c> System<'c> + Send + 'a,
     {
-        use hashbrown::hash_map::Entry;
-
         let id = self.next_id();
 
         let dependencies = dep

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -33,10 +33,9 @@
 //! running times of the groups of this stage get closer to each other (called
 //! balanced in code).
 
-use std::fmt;
+use std::{collections::HashMap, fmt};
 
 use arrayvec::ArrayVec;
-use hashbrown::HashMap;
 use smallvec::SmallVec;
 
 use crate::{

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,6 +1,8 @@
-use std::{any::TypeId, marker::PhantomData};
-
-use hashbrown::HashMap;
+use std::{
+    any::TypeId,
+    collections::{hash_map::Entry, HashMap},
+    marker::PhantomData,
+};
 
 use crate::{Resource, ResourceId, World};
 
@@ -252,8 +254,6 @@ impl<T: ?Sized> MetaTable<T> {
         R: Resource,
         T: CastFrom<R> + 'static,
     {
-        use hashbrown::hash_map::Entry;
-
         let thin_ptr = r as *const R as usize;
         let casted_ptr = <T as CastFrom<R>>::cast(r);
         let thin_casted_ptr = casted_ptr as *const T as *const () as usize;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,7 +1,6 @@
 use std::{any::TypeId, marker::PhantomData};
 
 use hashbrown::HashMap;
-use mopa::Any;
 
 use crate::{Resource, ResourceId, World};
 
@@ -291,7 +290,7 @@ impl<T: ?Sized> MetaTable<T> {
     pub fn get<'a>(&self, res: &'a dyn Resource) -> Option<&'a T> {
         unsafe {
             self.indices
-                .get(&Any::get_type_id(res))
+                .get(&res.type_id())
                 .map(move |&ind| &*self.fat[ind].create_ptr(res as *const _ as *const ()))
         }
     }
@@ -301,7 +300,7 @@ impl<T: ?Sized> MetaTable<T> {
     /// registered), this will return `None`.
     pub fn get_mut<'a>(&self, res: &'a dyn Resource) -> Option<&'a mut T> {
         unsafe {
-            self.indices.get(&Any::get_type_id(res)).map(move |&ind| {
+            self.indices.get(&res.type_id()).map(move |&ind| {
                 &mut *(self.fat[ind].create_ptr::<T>(res as *const _ as *const ()) as *mut T)
             })
         }

--- a/src/world/entry.rs
+++ b/src/world/entry.rs
@@ -5,8 +5,7 @@ use crate::{
     world::{FetchMut, Resource, ResourceId},
 };
 
-type StdEntry<'a, K, V> =
-    hashbrown::hash_map::Entry<'a, K, V, hashbrown::hash_map::DefaultHashBuilder>;
+type StdEntry<'a, K, V> = std::collections::hash_map::Entry<'a, K, V>;
 
 /// An entry to a resource of the `World` struct.
 /// This is similar to the Entry API found in the standard library.

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -7,13 +7,12 @@ pub use self::{
 };
 
 use std::{
-    any::TypeId,
+    any::{Any, TypeId},
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 
 use hashbrown::HashMap;
-use mopa::Any;
 
 use crate::{
     cell::{Ref, RefMut, TrustCell},
@@ -24,6 +23,7 @@ use self::entry::create_entry;
 
 mod data;
 mod entry;
+mod res_downcast;
 #[macro_use]
 mod setup;
 
@@ -103,16 +103,6 @@ pub trait Resource: Any + Send + Sync + 'static {}
 /// readers).
 #[cfg(not(feature = "parallel"))]
 pub trait Resource: Any + 'static {}
-
-mod __resource_mopafy_scope {
-    #![allow(clippy::all)]
-
-    use mopa::mopafy;
-
-    use super::Resource;
-
-    mopafy!(Resource);
-}
 
 #[cfg(feature = "parallel")]
 impl<T> Resource for T where T: Any + Send + Sync {}

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -8,11 +8,10 @@ pub use self::{
 
 use std::{
     any::{Any, TypeId},
+    collections::HashMap,
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
-
-use hashbrown::HashMap;
 
 use crate::{
     cell::{Ref, RefMut, TrustCell},

--- a/src/world/res_downcast/COPYRIGHT
+++ b/src/world/res_downcast/COPYRIGHT
@@ -1,0 +1,4 @@
+
+This project is dual-licensed under the terms of the MIT and Apache (version 2.0) licenses.
+
+Copyright (c) 2014 Chris Morgan and The Rust Project Developers

--- a/src/world/res_downcast/LICENSE-APACHE
+++ b/src/world/res_downcast/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/world/res_downcast/LICENSE-MIT
+++ b/src/world/res_downcast/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2014 Chris Morgan and The Rust Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/src/world/res_downcast/mod.rs
+++ b/src/world/res_downcast/mod.rs
@@ -1,0 +1,75 @@
+//! Code is based on https://github.com/chris-morgan/mopa
+//! with the macro inlined for `Resource`. License files can be found in the
+//! directory of this source file, see COPYRIGHT, LICENSE-APACHE and
+//! LICENSE-MIT.
+
+#[cfg(test)]
+mod tests;
+
+use std::any::TypeId;
+
+use crate::Resource;
+
+impl dyn Resource {
+    /// Returns the boxed value if it is of type `T`, or `Err(Self)` if it
+    /// isn't.
+    #[inline]
+    pub fn downcast<T: Resource>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+        if self.is::<T>() {
+            unsafe { Ok(self.downcast_unchecked()) }
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Returns the boxed value, blindly assuming it to be of type `T`.
+    /// If you are not *absolutely certain* of `T`, you *must not* call this.
+    #[inline]
+    pub unsafe fn downcast_unchecked<T: Resource>(self: Box<Self>) -> Box<T> {
+        Box::from_raw(Box::into_raw(self) as *mut T)
+    }
+
+    /// Returns true if the boxed type is the same as `T`
+    #[inline]
+    pub fn is<T: Resource>(&self) -> bool {
+        TypeId::of::<T>() == self.type_id()
+    }
+
+    /// Returns some reference to the boxed value if it is of type `T`, or
+    /// `None` if it isn't.
+    #[inline]
+    pub fn downcast_ref<T: Resource>(&self) -> Option<&T> {
+        if self.is::<T>() {
+            unsafe { Some(self.downcast_ref_unchecked()) }
+        } else {
+            Option::None
+        }
+    }
+
+    /// Returns a reference to the boxed value, blindly assuming it to be of
+    /// type `T`. If you are not *absolutely certain* of `T`, you *must not*
+    /// call this.
+    #[inline]
+    pub unsafe fn downcast_ref_unchecked<T: Resource>(&self) -> &T {
+        &*(self as *const Self as *const T)
+    }
+
+    /// Returns some mutable reference to the boxed value if it is of type `T`,
+    /// or `None` if it isn't.
+    #[inline]
+    pub fn downcast_mut<T: Resource>(&mut self) -> Option<&mut T> {
+        if self.is::<T>() {
+            unsafe { Some(self.downcast_mut_unchecked()) }
+        } else {
+            Option::None
+        }
+    }
+
+    /// Returns a mutable reference to the boxed value, blindly assuming it to
+    /// be of type `T`. If you are not *absolutely certain* of `T`, you
+    /// *must not* call this.
+    #[inline]
+    pub unsafe fn downcast_mut_unchecked<T: Resource>(&mut self) -> &mut T {
+        &mut *(self as *mut Self as *mut T)
+    }
+}

--- a/src/world/res_downcast/tests.rs
+++ b/src/world/res_downcast/tests.rs
@@ -1,0 +1,30 @@
+use std::any::TypeId;
+
+use crate::Resource;
+
+pub struct MyResource {}
+pub struct AnotherResource {}
+
+#[test]
+fn dyn_has_correct_type_id() {
+    let my_resource = MyResource {};
+    let my_resource_dyn: &dyn Resource = &my_resource;
+
+    assert_eq!(my_resource_dyn.type_id(), TypeId::of::<MyResource>());
+}
+
+#[test]
+fn downcast_allowed() {
+    let my_resource = MyResource {};
+    let my_resource_dyn: &dyn Resource = &my_resource;
+
+    assert!(my_resource_dyn.downcast_ref::<MyResource>().is_some());
+}
+
+#[test]
+fn downcast_disallowed() {
+    let my_resource = MyResource {};
+    let my_resource_dyn: &dyn Resource = &my_resource;
+
+    assert!(my_resource_dyn.downcast_ref::<AnotherResource>().is_none());
+}


### PR DESCRIPTION
Fixes #217

- The previous implementation uses `mopa`, which has a known safety
issue: https://github.com/chris-morgan/mopa/issues/13
- This commit essentially inlines the code generated by
the `mopafy!` macro provided by `mopa`, thus removing the
dependency
- Since `mopa::Any` was part of the public interface of the `Resource`
trait, this is technically a breaking change

Thank you to @Cypher1 for reporting this issue