### PR TITLE
Use ahash instead of SipHash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     branches:
-      - '**'
+      - "**"
 
 name: CI
 
@@ -20,7 +20,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.56.1  # MSRV
+          - 1.56.1 # MSRV
 
     timeout-minutes: 10
 
@@ -36,6 +36,13 @@ jobs:
         with:
           command: build
           args: --verbose --no-default-features
+
+      - name: Clippy lints
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all --tests -- -D warnings
+        if: matrix.rust == 'stable'
 
       - uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ edition = "2021"
 rust-version = "1.56.1"
 
 [dependencies]
+ahash = "0.7.6"
 arrayvec = "0.7.2"
 rayon = { version = "1.5.0", optional = true }
 shred-derive = { path = "shred-derive", version = "0.6.3", optional = true }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
-msrv = "1.40"
+msrv = "1.56.1"
+disallowed-types = ["std::collections::HashMap"]

--- a/examples/dyn_sys_data.rs
+++ b/examples/dyn_sys_data.rs
@@ -253,14 +253,14 @@ fn main() {
     let mut res = World::empty();
 
     {
-        let mut table = res.entry().or_insert_with(|| ReflectionTable::new());
+        let mut table = res.entry().or_insert_with(ReflectionTable::new);
 
         table.register(&Foo);
         table.register(&Bar);
     }
 
     {
-        let mut table = res.entry().or_insert_with(|| ResourceTable::new());
+        let mut table = res.entry().or_insert_with(ResourceTable::new);
         table.register::<Foo>("Foo");
         table.register::<Bar>("Bar");
     }

--- a/examples/dyn_sys_data.rs
+++ b/examples/dyn_sys_data.rs
@@ -7,8 +7,8 @@
 
 extern crate shred;
 
-// in a real application you would use `fnv`
-use std::collections::HashMap;
+// faster alternative to std's HashMap
+use ahash::AHashMap as HashMap;
 
 use shred::{
     cell::{Ref, RefMut},
@@ -283,7 +283,5 @@ fn main() {
     loop {
         dispatcher.dispatch(&res);
         scripts.dispatch(&res);
-
-        break;
     }
 }

--- a/examples/dynamic_resource_id.rs
+++ b/examples/dynamic_resource_id.rs
@@ -13,7 +13,8 @@
 //! make it easier to understand. Make sure you understood a step before you go
 //! to the next.
 
-use std::collections::HashMap;
+// alternative hasher that's faster than std's
+use ahash::AHashMap as HashMap;
 
 use shred::{Accessor, AccessorCow, DynamicSystemData, Fetch, ResourceId, RunNow, System, World};
 
@@ -30,13 +31,19 @@ pub struct ScriptingInterface {
     type_map: HashMap<String, u64>,
 }
 
-impl ScriptingInterface {
-    pub fn new() -> Self {
+impl Default for ScriptingInterface {
+    fn default() -> Self {
         ScriptingInterface {
             id_alloc: 1, /* Start with `1` so systems don't fetch it accidentally (via
                           * `Fetch<ScriptingResource>`) */
             type_map: HashMap::new(),
         }
+    }
+}
+
+impl ScriptingInterface {
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Registers a run-time resource as `name` and adds it to `world`.
@@ -116,7 +123,7 @@ impl ScriptingResAccessor {
 
         ScriptingResAccessor {
             reads: reads
-                .into_iter()
+                .iter()
                 .flat_map(|&name| interface.resource_id(name))
                 .collect(),
         }

--- a/src/dispatch/async_dispatcher.rs
+++ b/src/dispatch/async_dispatcher.rs
@@ -144,17 +144,10 @@ enum Data<R> {
 
 impl<R> Data<R> {
     fn inner(&mut self) -> &mut Inner<R> {
-        let new_self;
-
-        match *self {
-            Data::Inner(ref mut inner) => return inner,
-            Data::Rx(ref mut rx) => {
-                let inner = rx.recv().expect("Sender dropped");
-                new_self = Data::Inner(inner);
-            }
-        }
-
-        *self = new_self;
+        *self = match self {
+            Data::Inner(inner) => return inner,
+            Data::Rx(rx) => Data::Inner(rx.recv().expect("Sender dropped")),
+        };
 
         self.inner()
     }

--- a/src/dispatch/batch.rs
+++ b/src/dispatch/batch.rs
@@ -298,8 +298,8 @@ mod tests {
             let tomato_store = world.fetch::<TomatoStore>();
             assert!(!potato_store.is_store_open);
             assert!(!tomato_store.is_store_open);
-            assert_eq!(potato_store.potato_count, 50 - (1 * 3 * 10));
-            assert_eq!(tomato_store.tomato_count, 50 - (1 * 3 * 10));
+            assert_eq!(potato_store.potato_count, 50 - (3 * 10));
+            assert_eq!(tomato_store.tomato_count, 50 - (3 * 10));
         }
     }
 
@@ -362,8 +362,8 @@ mod tests {
             let customer_wallet = world.fetch::<CustomerWallet>();
             assert!(!potato_store.is_store_open);
             assert!(!tomato_store.is_store_open);
-            assert_eq!(potato_store.potato_count, 50 - (1 * 3 * 10));
-            assert_eq!(tomato_store.tomato_count, 50 - (1 * 3 * 10));
+            assert_eq!(potato_store.potato_count, 50 - (3 * 10));
+            assert_eq!(tomato_store.tomato_count, 50 - (3 * 10));
             assert_eq!(customer_wallet.cents_count, 2000 - ((50 + 150) * 3 * 10));
         }
     }

--- a/src/dispatch/builder.rs
+++ b/src/dispatch/builder.rs
@@ -1,7 +1,6 @@
-use std::{
-    collections::{hash_map::Entry, HashMap},
-    fmt,
-};
+use std::{collections::hash_map::Entry, fmt};
+
+use ahash::AHashMap as HashMap;
 
 #[cfg(feature = "parallel")]
 use crate::dispatch::dispatcher::ThreadPoolWrapper;

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -282,9 +282,9 @@ impl<'a> StagesBuilder<'a> {
         (self.barrier..self.stages.len())
             .map(|stage| {
                 let conflict = Self::find_conflict(
-                    &*self.ids,
-                    &*self.reads,
-                    &*self.writes,
+                    &self.ids,
+                    &self.reads,
+                    &self.writes,
                     stage,
                     new_reads.clone(),
                     new_writes.clone(),
@@ -435,7 +435,7 @@ mod tests {
 
     #[test]
     fn check_intersection_basic() {
-        assert!(check_intersection((&[1, 5]).iter(), (&[2, 5]).iter()));
+        assert!(check_intersection([1, 5].iter(), [2, 5].iter()));
     }
 
     #[test]

--- a/src/dispatch/stage.rs
+++ b/src/dispatch/stage.rs
@@ -33,8 +33,9 @@
 //! running times of the groups of this stage get closer to each other (called
 //! balanced in code).
 
-use std::{collections::HashMap, fmt};
+use std::fmt;
 
+use ahash::AHashMap as HashMap;
 use arrayvec::ArrayVec;
 use smallvec::SmallVec;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //! `ParSeq`. Using it is bit trickier, but it allows dispatching without any
 //! virtual function calls.
 
-#![deny(unused_must_use)]
+#![deny(unused_must_use, clippy::disallowed_types)]
 #![warn(missing_docs)]
 
 pub mod cell;

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -17,10 +17,10 @@ unsafe impl<T> Sync for Invariant<T> where T: ?Sized {}
 /// This trait is required to be implemented for a trait to be compatible with
 /// the meta table.
 ///
-/// # Memory safety
+/// # Safety
 ///
-/// Not casting `self` but e.g. a field to the trait object can result in severe
-/// memory safety issues.
+/// Not casting `self` but e.g. a field to the trait object will result in
+/// Undefined Bahavior.
 ///
 /// # Examples
 ///

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -1,8 +1,6 @@
-use std::{
-    any::TypeId,
-    collections::{hash_map::Entry, HashMap},
-    marker::PhantomData,
-};
+use std::{any::TypeId, collections::hash_map::Entry, marker::PhantomData};
+
+use ahash::AHashMap as HashMap;
 
 use crate::{Resource, ResourceId, World};
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -97,8 +97,8 @@ where
     type Target = AccessorTy<'a, T>;
 
     fn deref(&self) -> &AccessorTy<'a, T> {
-        match *self {
-            AccessorCow::Ref(r) => &*r,
+        match self {
+            AccessorCow::Ref(r) => r,
             AccessorCow::Owned(ref o) => o,
         }
     }

--- a/src/world/data.rs
+++ b/src/world/data.rs
@@ -28,7 +28,7 @@ where
     type Target = T;
 
     fn deref(&self) -> &T {
-        &*self.inner
+        &self.inner
     }
 }
 
@@ -83,7 +83,7 @@ where
     type Target = T;
 
     fn deref(&self) -> &T {
-        &*self.inner
+        &self.inner
     }
 }
 
@@ -92,7 +92,7 @@ where
     T: Resource,
 {
     fn deref_mut(&mut self) -> &mut T {
-        &mut *self.inner
+        &mut self.inner
     }
 }
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -661,7 +661,7 @@ mod tests {
 
         world.exec(|(float, boolean): (Read<f32>, Read<bool>)| {
             assert_eq!(*float, 0.0);
-            assert_eq!(*boolean, false);
+            assert!(!*boolean);
         });
 
         world.exec(|(mut float, mut boolean): (Write<f32>, Write<bool>)| {
@@ -671,7 +671,7 @@ mod tests {
 
         world.exec(|(float, boolean): (Read<f32>, ReadExpect<bool>)| {
             assert_eq!(*float, 4.3);
-            assert_eq!(*boolean, true);
+            assert!(*boolean);
         });
     }
 

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -8,10 +8,11 @@ pub use self::{
 
 use std::{
     any::{Any, TypeId},
-    collections::HashMap,
     marker::PhantomData,
     ops::{Deref, DerefMut},
 };
+
+use ahash::AHashMap as HashMap;
 
 use crate::{
     cell::{Ref, RefMut, TrustCell},

--- a/src/world/res_downcast/mod.rs
+++ b/src/world/res_downcast/mod.rs
@@ -23,7 +23,12 @@ impl dyn Resource {
     }
 
     /// Returns the boxed value, blindly assuming it to be of type `T`.
+    ///
+    /// # Safety
+    ///
     /// If you are not *absolutely certain* of `T`, you *must not* call this.
+    /// Using anything other than the correct type `T` for this `Resource`
+    /// will result in UB.
     #[inline]
     pub unsafe fn downcast_unchecked<T: Resource>(self: Box<Self>) -> Box<T> {
         Box::from_raw(Box::into_raw(self) as *mut T)
@@ -47,8 +52,13 @@ impl dyn Resource {
     }
 
     /// Returns a reference to the boxed value, blindly assuming it to be of
-    /// type `T`. If you are not *absolutely certain* of `T`, you *must not*
-    /// call this.
+    /// type `T`.
+    ///
+    /// # Safety
+    ///
+    /// If you are not *absolutely certain* of `T`, you *must not* call this.
+    /// Using anything other than the correct type `T` for this `Resource`
+    /// will result in UB.
     #[inline]
     pub unsafe fn downcast_ref_unchecked<T: Resource>(&self) -> &T {
         &*(self as *const Self as *const T)
@@ -66,8 +76,13 @@ impl dyn Resource {
     }
 
     /// Returns a mutable reference to the boxed value, blindly assuming it to
-    /// be of type `T`. If you are not *absolutely certain* of `T`, you
-    /// *must not* call this.
+    /// be of type `T`.
+    ///
+    /// # Safety
+    ///
+    /// If you are not *absolutely certain* of `T`, you *must not* call this.
+    /// Using anything other than the correct type `T` for this `Resource`
+    /// will result in UB.
     #[inline]
     pub unsafe fn downcast_mut_unchecked<T: Resource>(&mut self) -> &mut T {
         &mut *(self as *mut Self as *mut T)


### PR DESCRIPTION
Partially reverts 496564035390f085f677ed4e37852b1a5b4854cd (we use ahash again, but without using `hashbrown` which is just a copy of `std::collections::HashMap` with `ahash` as the default).
