### PR TITLE
Fix remaining issues identified by Miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,4 +71,7 @@ jobs:
           rustup override set nightly
           cargo miri setup
       - name: Test with Miri
-        run: cargo miri test
+        # Miri currently reports leaks in some tests so we disable that check
+        # here (might be due to ptr-int-ptr in crossbeam-epoch so might be
+        # resolved in future versions of that crate).
+        run: MIRIFLAGS="-Zmiri-ignore-leaks" cargo miri test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.59.0 # MSRV
+          - 1.65.0 # MSRV
 
     timeout-minutes: 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
   miri:
     name: "Miri"
     runs-on: ubuntu-latest
-    continue-on-error: true # Needed until all Miri errors are fixed
     steps:
       - uses: actions/checkout@v3
       - name: Install Miri

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["concurrency"]
 license = "MIT OR Apache-2.0"
 exclude = ["bors.toml", ".travis.yml"]
 edition = "2021"
-rust-version = "1.59.0"
+rust-version = "1.65.0"
 
 [dependencies]
 ahash = "0.7.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ shred-derive = { path = "shred-derive", version = "0.6.3" }
 [features]
 default = ["parallel", "shred-derive"]
 parallel = ["rayon"]
+nightly = []
 
 [[example]]
 name = "async"

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,9 +1,5 @@
 #![feature(test)]
 
-extern crate cgmath;
-extern crate shred;
-#[macro_use]
-extern crate shred_derive;
 extern crate test;
 
 use std::ops::{Index, IndexMut};

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,2 @@
-msrv = "1.56.1"
+msrv = "1.65.0"
 disallowed-types = ["std::collections::HashMap"]

--- a/examples/basic_dispatch.rs
+++ b/examples/basic_dispatch.rs
@@ -22,7 +22,7 @@ impl<'a> System<'a> for PrintSystem {
         println!("{:?}", &*b);
 
         *b = ResB; // We can mutate ResB here
-        // because it's `Write`.
+                   // because it's `Write`.
     }
 }
 

--- a/examples/dyn_sys_data.rs
+++ b/examples/dyn_sys_data.rs
@@ -99,11 +99,7 @@ unsafe impl<T> CastFrom<T> for dyn Reflection
 where
     T: Reflection + 'static,
 {
-    fn cast(t: &T) -> &Self {
-        t
-    }
-
-    fn cast_mut(t: &mut T) -> &mut Self {
+    fn cast(t: *mut T) -> *mut Self {
         t
     }
 }
@@ -253,8 +249,8 @@ fn main() {
     {
         let mut table = res.entry().or_insert_with(ReflectionTable::new);
 
-        table.register(&Foo);
-        table.register(&Bar);
+        table.register::<Foo>();
+        table.register::<Bar>();
     }
 
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(feature = "nightly", feature(ptr_metadata, strict_provenance))]
 //! **Sh**ared **re**source **d**ispatcher
 //!
 //! This library allows to dispatch

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@
 //! virtual function calls.
 
 #![deny(unused_must_use, clippy::disallowed_types)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
 
 /// Re-exports from [`atomic_refcell`]

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -64,6 +64,7 @@ where
 {
     type Item = AtomicRef<'a, T>;
 
+    #[allow(clippy::borrowed_box)] // variant of https://github.com/rust-lang/rust-clippy/issues/5770
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         loop {
             let resource_id = match self.tys.get(self.index) {

--- a/src/world/res_downcast/mod.rs
+++ b/src/world/res_downcast/mod.rs
@@ -16,6 +16,7 @@ impl dyn Resource {
     #[inline]
     pub fn downcast<T: Resource>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
         if self.is::<T>() {
+            // SAFETY: We just checked that the type is `T`.
             unsafe { Ok(self.downcast_unchecked()) }
         } else {
             Err(self)
@@ -31,7 +32,8 @@ impl dyn Resource {
     /// will result in UB.
     #[inline]
     pub unsafe fn downcast_unchecked<T: Resource>(self: Box<Self>) -> Box<T> {
-        Box::from_raw(Box::into_raw(self) as *mut T)
+        // SAFETY: Caller promises the concrete type is `T`.
+        unsafe { Box::from_raw(Box::into_raw(self) as *mut T) }
     }
 
     /// Returns true if the boxed type is the same as `T`
@@ -45,6 +47,7 @@ impl dyn Resource {
     #[inline]
     pub fn downcast_ref<T: Resource>(&self) -> Option<&T> {
         if self.is::<T>() {
+            // SAFETY: We just checked that the type is `T`.
             unsafe { Some(self.downcast_ref_unchecked()) }
         } else {
             Option::None
@@ -61,7 +64,8 @@ impl dyn Resource {
     /// will result in UB.
     #[inline]
     pub unsafe fn downcast_ref_unchecked<T: Resource>(&self) -> &T {
-        &*(self as *const Self as *const T)
+        // SAFETY: Caller promises the concrete type is `T`.
+        unsafe { &*(self as *const Self as *const T) }
     }
 
     /// Returns some mutable reference to the boxed value if it is of type `T`,
@@ -69,6 +73,7 @@ impl dyn Resource {
     #[inline]
     pub fn downcast_mut<T: Resource>(&mut self) -> Option<&mut T> {
         if self.is::<T>() {
+            // SAFETY: We just checked that the type is `T`.
             unsafe { Some(self.downcast_mut_unchecked()) }
         } else {
             Option::None
@@ -85,6 +90,7 @@ impl dyn Resource {
     /// will result in UB.
     #[inline]
     pub unsafe fn downcast_mut_unchecked<T: Resource>(&mut self) -> &mut T {
-        &mut *(self as *mut Self as *mut T)
+        // SAFETY: Caller promises the concrete type is `T`.
+        unsafe { &mut *(self as *mut Self as *mut T) }
     }
 }

--- a/tests/meta_table_safety_113.rs
+++ b/tests/meta_table_safety_113.rs
@@ -18,13 +18,12 @@ struct MultipleData {
 }
 
 unsafe impl CastFrom<MultipleData> for dyn PointsToU64 {
-    fn cast(t: &MultipleData) -> &Self {
-        // this is wrong and will cause a panic
-        &t.pointer
-    }
+    fn cast(t: *mut MultipleData) -> *mut Self {
+        // note, this also assumes the pointer is non-null and probably other things which we can't
+        // assume in an implementation of `CastFrom`.
 
-    fn cast_mut(t: &mut MultipleData) -> &mut Self {
-        &mut t.pointer
+        // this is wrong and will cause a panic
+        unsafe { core::ptr::addr_of_mut!((*t).pointer) }
     }
 }
 
@@ -36,7 +35,7 @@ fn test_panics() {
         _number: 0x0, // this will be casted to a pointer, then dereferenced
         pointer: Box::new(42),
     };
-    table.register(&md);
+    table.register::<MultipleData>();
     if let Some(t) = table.get(&md) {
         println!("{}", t.get_u64());
     }


### PR DESCRIPTION
Addresses miri's complaints about vtable shenanigans in MetaTable implementation.

* Before pointer casts and reads/deferences were used to extract/attach a vtable pointer as a `usize` (which includes operations that miri reports as UB). Now a function pointer is stored for each concrete type, this points to a function that knows the types involved and can thus leverage safe code to upcast a pointer from the concrete type to a trait object.
* `CastFrom` trait now uses a single method that operates on pointers rather than two separate methods for `&T` and `&mut T` (this is so that we don't have to store a separate function pointer for each case). Safety requirements for implementing `CastFrom` having been modified (but can be trivially met by just returning the provided pointer (letting it be automatically coerced to a pointer to the trait object)).
* `MetaTable::register` no longer requires an instance of the type being registered.
* `MetaTable::get_mut` no longer converts a shared reference to an exclusive one (this was most likely UB).
* `MetaIter`/`MetaIterMut` no longer cast aside the `Ref`/`RefMut` guard on each element (which would allow safe code to create aliasing references to items being yielded from these iterators). Instead, `Ref::map` and `RefMut::map` are used.
* Converted meta iterators to use a loop rather than recursion for advancing past missing values from try_fetch_internal (not sure if this avoids impacting performance though...).

Misc changes:

* Added crate-level deny for `unsafe_op_in_unsafe_fn` and added unsafe blocks where needed. This makes it easier to identify where unsafe operations are occuring and to document them.
* Bump MSRV to 1.65.0, since we are already bumping it in specs to use GATs and it gives some convenient functions for working with pointers.
* Remove unnecessary `extern crate`s in benches/bench.rs (not needed in newer rust editions).

--------

**Update:** This now adds a `nightly` feature which uses the unstable `ptr_metadata` feature for a more efficient implementation of the `MetaTable`.