### PR TITLE
Update Debug impls for cell::Ref/cell::RefMut to show value (and bump MSRV)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.56.1 # MSRV
+          - 1.59.0 # MSRV
 
     timeout-minutes: 10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Increase MSRV to 1.59.0 because of `rayon-core v1.11.0`.
+
 ## 0.14.1 (2022-07-14)
 
 * Undo performance regression from removing `hashbrown` by using `ahash` hasher

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["concurrency"]
 license = "MIT OR Apache-2.0"
 exclude = ["bors.toml", ".travis.yml"]
 edition = "2021"
-rust-version = "1.56.1"
+rust-version = "1.59.0"
 
 [dependencies]
 ahash = "0.7.6"

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -5,7 +5,7 @@ use core::ptr::NonNull;
 use std::{
     cell::UnsafeCell,
     error::Error,
-    fmt::{Display, Error as FormatError, Formatter},
+    fmt::{Debug, Display, Error as FormatError, Formatter},
     ops::{Deref, DerefMut},
     sync::atomic::{AtomicUsize, Ordering},
     usize,
@@ -41,7 +41,6 @@ impl Error for InvalidBorrow {
 /// An immutable reference to data in a `TrustCell`.
 ///
 /// Access the value via `std::ops::Deref` (e.g. `*val`)
-#[derive(Debug)]
 pub struct Ref<'a, T: ?Sized + 'a> {
     flag: &'a AtomicUsize,
     value: NonNull<T>,
@@ -135,10 +134,15 @@ impl<'a, T: ?Sized> Clone for Ref<'a, T> {
     }
 }
 
+impl<'a, T: ?Sized + Debug> Debug for Ref<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FormatError> {
+        <T as Debug>::fmt(self, f)
+    }
+}
+
 /// A mutable reference to data in a `TrustCell`.
 ///
 /// Access the value via `std::ops::DerefMut` (e.g. `*val`)
-#[derive(Debug)]
 pub struct RefMut<'a, T: ?Sized + 'a> {
     flag: &'a AtomicUsize,
     value: NonNull<T>,
@@ -242,6 +246,12 @@ impl<'a, T: ?Sized> DerefMut for RefMut<'a, T> {
 impl<'a, T: ?Sized> Drop for RefMut<'a, T> {
     fn drop(&mut self) {
         self.flag.store(0, Ordering::Release)
+    }
+}
+
+impl<'a, T: ?Sized + Debug> Debug for RefMut<'a, T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), FormatError> {
+        <T as Debug>::fmt(self, f)
     }
 }
 


### PR DESCRIPTION
https://github.com/amethyst/shred/pull/223 accidentally regressed the debug impls, here we now show the referenced values again but the atomic counter is omitted