### PR TITLE
Bump ahash dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 rust-version = "1.65.0"
 
 [dependencies]
-ahash = "0.7.6"
+ahash = "0.8.5"
 arrayvec = "0.7.2"
 atomic_refcell = "0.1.10" # part of public API
 rayon = { version = "1.5.0", optional = true }


### PR DESCRIPTION
The previous version had a bug, and was yanked.