### PR TITLE
Update aHash / tynm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ edition = "2021"
 rust-version = "1.65.0"
 
 [dependencies]
-ahash = "0.8.5"
+ahash = "0.8.6"
 arrayvec = "0.7.2"
 atomic_refcell = "0.1.10" # part of public API
 rayon = { version = "1.5.0", optional = true }
 shred-derive = { path = "shred-derive", version = "0.7.0", optional = true }
 smallvec = "1.6.1"
-tynm = "0.1.6"
+tynm = "0.1.7"
 
 [workspace]
 members = ["shred-derive"]


### PR DESCRIPTION
update aHash because of their license dependency and update tynm because their minimum version no longer builds in future rust compilers